### PR TITLE
fix: deadcode

### DIFF
--- a/renderer/components/Dialogs/dispensingWait.tsx
+++ b/renderer/components/Dialogs/dispensingWait.tsx
@@ -9,16 +9,15 @@ interface DispensingWaitProps {
   onOpenDeactive: () => void;
 }
 
-const DispensingWait = ({ slotNo, hn, onClose, onOpenDeactive }: DispensingWaitProps) => {
-
-const handleCheckLockedBack = () => {
-  ipcRenderer.invoke("check-locked-back", {slotId: slotNo});
-}
-
-  
-
-
-
+const DispensingWait = ({
+  slotNo,
+  hn,
+  onClose,
+  onOpenDeactive,
+}: DispensingWaitProps) => {
+  const handleCheckLockedBack = () => {
+    ipcRenderer.invoke("check-locked-back", { slotId: slotNo });
+  };
 
   return (
     <>
@@ -26,7 +25,12 @@ const handleCheckLockedBack = () => {
         <div className="flex flex-col rounded-md overflow-hidden gap-2 max-w-[300px]">
           <div className="flex justify-between shadow-xl p-3 font-bold text-xl text-center">
             <span className={"font-bold"}>HN: {hn}</span>
-	    <button onClick={onOpenDeactive} className="btn btn-ghost btn-circle btn-sm font-bold text-xl">!</button>
+            <button
+              onClick={onOpenDeactive}
+              className="btn btn-ghost btn-circle btn-sm font-bold text-xl"
+            >
+              !
+            </button>
           </div>
           <div className="flex flex-col p-3 flex-wrap jusitfy-center items-center">
             <div className="font-bold text-[#ff0000]">
@@ -36,7 +40,9 @@ const handleCheckLockedBack = () => {
               เอายาออกจากช่องแล้วปิดช่อง จากนั้นกดปุ่มตกลง
             </p>
             <Loading />
-            <button className="btn" onClick={handleCheckLockedBack}>ตกลง</button>
+            <button className="btn" onClick={handleCheckLockedBack}>
+              ตกลง
+            </button>
           </div>
         </div>
       </div>

--- a/renderer/components/Dialogs/lockWait.tsx
+++ b/renderer/components/Dialogs/lockWait.tsx
@@ -2,7 +2,6 @@ import { ipcRenderer } from "electron";
 import { useEffect } from "react";
 import Loading from "../Shared/Loading";
 
-
 interface LockWaitProps {
   slotNo: number;
   hn: string;
@@ -11,18 +10,21 @@ interface LockWaitProps {
 }
 
 const LockWait = ({ slotNo, hn, onClose, onOpenDeactive }: LockWaitProps) => {
-
-const handleCheckLockedBack = () => {
-  ipcRenderer.invoke("check-locked-back", {slotId: slotNo});
-}
-
+  const handleCheckLockedBack = () => {
+    ipcRenderer.invoke("check-locked-back", { slotId: slotNo });
+  };
 
   return (
     <>
       <div className="flex flex-col rounded-md overflow-hidden gap-2 max-w-[300px]">
         <div className="flex justify-between items-center shadow-xl px-3 py-2 font-bold text-xl">
           HN: {hn}
-          <button onClick={onOpenDeactive}  className="btn btn-circle btn-sm btn-ghost font-bold text-xl">!</button>
+          <button
+            onClick={onOpenDeactive}
+            className="btn btn-circle btn-sm btn-ghost font-bold text-xl"
+          >
+            !
+          </button>
         </div>
         <div className="flex flex-col p-3 flex-wrap jusitfy-center items-center">
           <div className="font-bold text-[#ff0000]">
@@ -32,9 +34,10 @@ const handleCheckLockedBack = () => {
             นำยาเข้าช่อง #{slotNo} เปิด และปิดช่อง จากนั้นกดปุ่มตกลง
           </p>
           <Loading />
-          <button className="btn" onClick={handleCheckLockedBack}>ตกลง</button>
+          <button className="btn" onClick={handleCheckLockedBack}>
+            ตกลง
+          </button>
         </div>
-
       </div>
     </>
   );


### PR DESCRIPTION
This pull request makes minor UI improvements and code style adjustments to the `DispensingWait` and `LockWait` dialog components. The main focus is on improving code readability and maintaining consistent formatting for button elements and function definitions.

UI and code formatting improvements:

* Reformatted the `onOpenDeactive` button in both `DispensingWait` and `LockWait` dialogs for better readability and consistent styling. [[1]](diffhunk://#diff-8b9c259e506fed2bef10476b69b88f505e939db61c3e7d13d4bf9b8038be63c3L12-R33) [[2]](diffhunk://#diff-a2c571e9ed3eca314bc2c71564f9c7d5bff5ce062f9748aff7bebb3848773ea5L14-R27)
* Reformatted the "ตกลง" (Confirm) button in both dialogs to improve code clarity and maintain consistent button formatting. [[1]](diffhunk://#diff-8b9c259e506fed2bef10476b69b88f505e939db61c3e7d13d4bf9b8038be63c3L39-R45) [[2]](diffhunk://#diff-a2c571e9ed3eca314bc2c71564f9c7d5bff5ce062f9748aff7bebb3848773ea5L35-L37)
* Fixed minor whitespace and formatting issues in function definitions for both components. [[1]](diffhunk://#diff-8b9c259e506fed2bef10476b69b88f505e939db61c3e7d13d4bf9b8038be63c3L12-R33) [[2]](diffhunk://#diff-a2c571e9ed3eca314bc2c71564f9c7d5bff5ce062f9748aff7bebb3848773ea5L14-R27)
* Removed an unnecessary blank line in `lockWait.tsx` to clean up the import section.