### PR TITLE
feat: migrate dispensing-continue handler from KU16 to CU12 architecture

### DIFF
--- a/main/background.ts
+++ b/main/background.ts
@@ -30,7 +30,7 @@ import { getSetting } from "./setting/getSetting";
 import { getSettingHandler } from "./setting/ipcMain/getSetting";
 import { updateSettingHandler } from "./setting/ipcMain/updateSetting";
 import { checkLockedBackHandler } from "./cu12/ipcMain/checkLockedBack";
-import { dispenseContinueHandler } from "./ku16/ipcMain/dispensing-continue";
+import { dispenseContinueHandler } from "./cu12/ipcMain/dispensing-continue";
 import { getPortListHandler } from "./cu12/ipcMain/getPortList";
 import { getUserHandler } from "./auth/ipcMain/getUser";
 import { getAllSlotsHandler } from "./setting/ipcMain/getAllSlots";
@@ -142,7 +142,7 @@ if (isProd) {
   dispenseHandler(cu12);
   resetHandler(cu12);
   // Keep existing handlers that work with CU12
-  dispenseContinueHandler(cu12 as any);
+  dispenseContinueHandler(cu12);
   // forceResetHanlder(cu12); // Keep existing for now
   deactiveHandler(cu12);
   // Note: These handlers expect KU16 type - comment out for now, will migrate if needed

--- a/main/cu12/ipcMain/dispensing-continue.ts
+++ b/main/cu12/ipcMain/dispensing-continue.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from "electron";
-import { KU16 } from "..";
+import { CU12Controller } from "..";
 import { logDispensing, logger } from "../../logger";
 import { User } from "../../../db/model/user.model";
-export const dispenseContinueHandler = (ku16: KU16) => {
+export const dispenseContinueHandler = (cu12: CU12Controller) => {
   ipcMain.handle("dispense-continue", async (event, payload) => {
     let userId = null;
     let userName = null;
@@ -28,10 +28,10 @@ export const dispenseContinueHandler = (ku16: KU16) => {
         message: "จ่ายยาสำเร็จยังมียาอยู่ในช่อง",
       });
 
-      await ku16.sleep(1000);
-      ku16.sendCheckState();
+      await cu12.sleep(1000);
+      cu12.sendCheckState();
     } catch (error) {
-      ku16.win.webContents.send("dispense-error", {
+      cu12.win.webContents.send("dispense-error", {
         message: "ไม่สามารถจ่ายยาได้กรุณาตรวจสอบรหัสผู้ใช้งานอีกครั้ง",
       });
 


### PR DESCRIPTION
## Summary
- Migrated dispensing-continue.ts handler from KU16 to CU12 architecture
- Updated import from KU16 to CU12Controller type for proper typing
- Removed type casting (cu12 as any) in background.ts
- Deleted original KU16 handler file
- Updated handler registration to use CU12 type

## Test plan
- [ ] Test "มีอีก" button in dispensing dialog works correctly
- [ ] Verify dispensing logs are created successfully  
- [ ] Confirm device communication (sendCheckState) functions properly
- [ ] Test error handling scenarios with invalid passkey
- [ ] Ensure no unintended side effects on other functionality

🤖 Generated with Claude Code